### PR TITLE
docs(butteraugli): document the (undocumented) cancellation API + flat-Vec on-ramp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      Everything below ships with the next publish. -->
 
 ### Added
-- Sub-8px images (down to 1×1) are now reflect(mirror)-padded up to the 8×8
-  floor and scored by `butteraugli` / `butteraugli_linear` instead of being
-  rejected with `ImageTooSmall`; the returned diffmap is cropped back to the
-  input size. Zero-dimension inputs still error. The strip API still
-  requires ≥8×8. (328cf8e)
+- Cooperative cancellation: `butteraugli_with_stop`, `butteraugli_linear_with_stop`,
+  and `butteraugli_strip_with_stop` mirror `butteraugli` / `butteraugli_linear` /
+  `butteraugli_strip` but take a trailing `stop: &dyn enough::Stop` token. The token
+  is checked at the outermost per-scale boundary of the core compute (one-shot) and
+  once per strip at the top of the strip loop — never inside the per-pixel
+  psycho/blur/malta/mask/opsin kernels — so a cancellation is honoured at scale /
+  strip granularity with zero hot-loop overhead. A new additive
+  `ButteraugliError::Cancelled(enough::StopReason)` variant is returned on cancel
+  (the enum is `#[non_exhaustive]`, so this is non-breaking). The non-`_with_stop`
+  functions delegate to the `_with_stop` versions with `enough::Unstoppable` (zero
+  cost). The `enough` crate is re-exported (`butteraugli::enough`) so callers can
+  name `Stop` / `Unstoppable` / `StopReason` without a direct dependency.
+  The warm-reference `ButteraugliReference` batch API (the codec-sweep hot path:
+  precompute the reference once, compare many distorted images) is covered too —
+  `compare_with_stop`, `compare_linear_with_stop`, `compare_srgb_with_stop`,
+  `compare_linear_imgref_with_stop` check the token at the warm-ref core's outermost
+  per-scale boundary (before the full-res + half-res `maybe_join` dispatch), and
+  `compare_strip_with_stop`, `compare_linear_strip_with_stop`,
+  `compare_strip_srgb_with_stop`, `compare_strip_linear_imgref_with_stop` thread it
+  into the already-per-strip-checked strip walker. Same non-breaking delegation: the
+  existing methods call the `_with_stop` versions with `enough::Unstoppable`.
 - `ButteraugliReference::drop_strip_source(&mut self)` — drops the retained reference-side source data (sRGB u8 or linear f32) so subsequent `compare_strip` / `compare_linear_strip` / `compare_strip_srgb` / `compare_strip_linear_imgref` calls return `InvalidParameter`. The non-strip `compare` / `compare_linear` / `compare_linear_planar` paths are unaffected. Use when the caller has determined that no strip dispatch will follow on this reference and wants to reclaim the per-pixel retention. (3e41f32)
 - `ButteraugliReference::shrink_to_fit(&mut self)` — drains the persistent `BufferPool`, releasing any cached transient buffers held between `compare` calls at the cost of one re-allocation on the next `compare` call. Cached XYB pyramid / mask / source data is retained (the warm-ref speedup over a cold `butteraugli()` call still applies). (3e41f32)
 - Versioned public-API surface snapshot at `docs/public-api/butteraugli.txt`, regenerated on every `cargo test` by `butteraugli/tests/public_api_doc.rs` (`ZEN_API_DOC=check` verifies in the CI lint job, `=off` skips); `justfile` recipes `fmt` / `api-doc` / `api-doc-check`. Dev-only — not part of the published package.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "almost-enough"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2040cad221332dbe816267e6f2b55032f53a297ceb4d97f8e612df471aa6dbc"
+dependencies = [
+ "enough",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,9 +155,11 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 name = "butteraugli"
 version = "0.9.4"
 dependencies = [
+ "almost-enough",
  "approx",
  "archmage",
  "chrono",
+ "enough",
  "imgref",
  "jpeg-decoder",
  "magetypes",
@@ -335,6 +346,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enough"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e1bd41ecce82c300d0c84fa35b080fa6db50a5398b18f1abf0357bb067549e"
 
 [[package]]
 name = "equivalent"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ sRGB u8 path decodes with the sRGB EOTF to linear before the same scaling.
 
 ### Example
 
+`Img`, `ImgRef`, `RGB8`, and `RGB` are re-exported from `butteraugli` (it
+wraps [`imgref`](https://crates.io/crates/imgref) and
+[`rgb`](https://crates.io/crates/rgb)), so you don't need to add those crates
+as separate dependencies.
+
 ```rust
 use butteraugli::{butteraugli, ButteraugliParams, Img, RGB8};
 
@@ -95,7 +100,53 @@ let result = butteraugli(img1.as_ref(), img2.as_ref(), &ButteraugliParams::defau
 println!("Score: {:.4}", result.score);
 ```
 
+#### Building `Img<RGB8>` from flat interleaved bytes
+
+Most decoders hand you a flat row-major `Vec<u8>` (3 bytes per pixel: `R, G,
+B, R, G, B, …`), not a `Vec<RGB8>`. Convert it once at the boundary — `RGB8`
+is constructed with `RGB8::new(r, g, b)`:
+
+```rust
+use butteraugli::{Img, RGB8};
+
+// `bytes.len()` must equal `width * height * 3`.
+fn img_from_rgb_bytes(bytes: &[u8], width: usize, height: usize) -> Img<Vec<RGB8>> {
+    assert_eq!(bytes.len(), width * height * 3);
+    let pixels: Vec<RGB8> = bytes
+        .chunks_exact(3)
+        .map(|c| RGB8::new(c[0], c[1], c[2]))
+        .collect();
+    Img::new(pixels, width, height)
+}
+```
+
+If your buffer is *strided* (each row padded to a wider stride than
+`width * 3`), build the `Vec<RGB8>` row by row and use
+`ImgRef::new_stride(&pixels, width, height, stride_in_pixels)` instead — the
+core handles stride without copying.
+
+> **RGBA input has no direct path.** Butteraugli scores RGB only; there is no
+> RGBA entry point, so drop the alpha channel first — and step by 4 keeping 3,
+> **not** `chunks_exact(3)`. Treating packed RGBA bytes as RGB via
+> `chunks_exact(3)` silently misaligns every pixel after the first and produces
+> a garbage score:
+>
+> ```rust
+> use butteraugli::RGB8;
+> // rgba: &[u8], 4 bytes per pixel (R, G, B, A)
+> let rgb: Vec<RGB8> = rgba
+>     .chunks_exact(4)
+>     .map(|p| RGB8::new(p[0], p[1], p[2])) // discard p[3] (alpha)
+>     .collect();
+> ```
+>
+> Butteraugli has no notion of transparency, so composite onto a known
+> background first if alpha is meaningful for your comparison.
+
 ### Difference Map
+
+The diffmap is an [`ImgVec<f32>`](https://docs.rs/imgref) (`Option<ImgVec<f32>>`
+on the result — `None` unless `with_compute_diffmap(true)` was set):
 
 ```rust
 let params = ButteraugliParams::default().with_compute_diffmap(true);
@@ -106,6 +157,21 @@ if let Some(diffmap) = result.diffmap {
     println!("Maximum local difference: {:.4}", max_diff);
 }
 ```
+
+### Types and Errors
+
+All the types you need for `use butteraugli::{…}` and `?`:
+
+| Item | Signature / type | Notes |
+|------|------------------|-------|
+| `ButteraugliResult` | `{ score: f64, pnorm_3: f64, diffmap: Option<ImgVec<f32>> }` | returned by every scoring fn |
+| `ButteraugliError` | `enum` (`#[non_exhaustive]`), `impl std::error::Error` | the error type for `?` |
+| `result.pnorm(p)` | `fn(&self, p: f64) -> Option<f64>` | `None` unless `compute_diffmap` was on |
+| `result.max_norm()` | `fn(&self) -> f64` | same value as `result.score` |
+| diffmap | `ImgVec<f32>` | re-exported from `imgref` |
+
+Because `ButteraugliError` implements `std::error::Error`, it composes with
+`?`, `Box<dyn Error>`, and `anyhow`/`eyre` out of the box.
 
 ### Aggregations
 
@@ -148,6 +214,89 @@ image in horizontal strips (3.8x lower peak heap at 40 MP, equivalent wall
 time): `butteraugli_strip` / `butteraugli_linear_strip` one-shot, or
 `ButteraugliReference::compare_strip` and friends with a cached reference.
 Strip scores match the full-image path to ~1e-2; see `ButteraugliStripConfig`.
+
+### Cancellation
+
+A full multi-scale comparison is not cheap, and on a server scoring an
+untrusted pair — or a codec sweep grinding through thousands of candidates
+against a warm reference — you sometimes need to abort a comparison already in
+flight (request timeout, client disconnect, sweep cancelled). Every slow entry
+point has a `*_with_stop` sibling that takes a trailing cooperative-cancellation
+token, `stop: &dyn enough::Stop` (from the
+[`enough`](https://crates.io/crates/enough) crate, **re-exported as
+`butteraugli::enough`** so you don't need a separate dependency):
+
+| Plain | Cancellable variant |
+|-------|---------------------|
+| `butteraugli` | `butteraugli_with_stop(img1, img2, params, stop)` |
+| `butteraugli_linear` | `butteraugli_linear_with_stop(img1, img2, params, stop)` |
+| `butteraugli_strip` | `butteraugli_strip_with_stop(img1, img2, params, strip_height, stop)` |
+| `ButteraugliReference::compare` | `compare_with_stop(rgb, stop)` |
+| `compare_linear` / `compare_srgb` / `compare_linear_imgref` | `compare_linear_with_stop` / `compare_srgb_with_stop` / `compare_linear_imgref_with_stop` |
+| `compare_strip` + variants | `compare_strip_with_stop` + variants |
+
+The token is checked **once at the outermost per-scale boundary** of the core
+compute (one-shot) and **once per strip** at the top of the strip loop — never
+inside the per-pixel kernels — so cancellation is honored at scale / strip
+granularity with zero hot-loop overhead. On a stop, the call returns
+`Err(ButteraugliError::Cancelled(enough::StopReason))` (the `Cancelled` variant
+is additive — `ButteraugliError` is `#[non_exhaustive]`).
+
+The plain functions are exactly their `_with_stop` counterpart called with
+`enough::Unstoppable` (a zero-cost no-op token), so there is no behavioral or
+performance difference when you don't need cancellation:
+
+```rust
+use butteraugli::{butteraugli_with_stop, ButteraugliParams};
+
+// A non-cancellable call — identical to `butteraugli(...)`.
+let result = butteraugli_with_stop(
+    img1.as_ref(),
+    img2.as_ref(),
+    &ButteraugliParams::default(),
+    &butteraugli::enough::Unstoppable, // never stops
+)?;
+```
+
+For a token you can actually trigger, add the
+[`almost-enough`](https://crates.io/crates/almost-enough) crate — its
+`Stopper` is `Arc`-based and `Clone`, so you hand a clone to the worker and
+cancel from anywhere (another thread, a timeout, a signal handler):
+
+```toml
+[dependencies]
+butteraugli = "0.9"
+almost-enough = "0.4.4"
+```
+
+```rust
+use almost_enough::Stopper;
+use butteraugli::{butteraugli_with_stop, ButteraugliParams};
+
+let stop = Stopper::new();           // live (not yet cancelled)
+let stop_for_worker = stop.clone();  // cheap Arc bump
+
+let handle = std::thread::spawn(move || {
+    butteraugli_with_stop(
+        img1.as_ref(),
+        img2.as_ref(),
+        &ButteraugliParams::default(),
+        &stop_for_worker,
+    )
+});
+
+// …elsewhere (timeout fired, request aborted, etc.):
+stop.cancel();
+
+match handle.join().unwrap() {
+    Err(butteraugli::ButteraugliError::Cancelled(_)) => { /* aborted cleanly */ }
+    other => { /* completed before the cancel landed */ let _ = other; }
+}
+```
+
+`almost-enough` also offers `Stopper::cancelled()` (a pre-cancelled token, handy
+in tests) and timeout/`OrStop` combinators; see its docs. Any type implementing
+`enough::Stop` works — you are not tied to `almost-enough`.
 
 ## Features
 

--- a/butteraugli/Cargo.toml
+++ b/butteraugli/Cargo.toml
@@ -57,6 +57,9 @@ magetypes.workspace = true
 imgref.workspace = true
 rgb.workspace = true
 rayon = { workspace = true, optional = true }
+# Cooperative cancellation trait (`&dyn enough::Stop`) for the `*_with_stop`
+# entry points. The crate is `std` (not `no_std`), so default features are fine.
+enough = "0.4.4"
 
 # C++ butteraugli bindings for parity testing (not on crates.io)
 # For local C++ parity testing, add jpegli-internals-sys to .cargo/config.toml
@@ -67,6 +70,9 @@ png = "0.18"
 
 # Testing utilities
 approx = "0.5"
+
+# Ergonomic cancellation tokens (`Stopper::cancelled()`) for cancellation tests
+almost-enough = "0.4.4"
 
 # Date/time for reference data generation
 chrono = "0.4"

--- a/butteraugli/src/diff.rs
+++ b/butteraugli/src/diff.rs
@@ -3,7 +3,6 @@
 //! This module ties together all the components to compute the
 //! perceptual difference between two images.
 
-use crate::ButteraugliParams;
 use crate::consts::{
     NORM1_HF, NORM1_HF_X, NORM1_MF, NORM1_MF_X, NORM1_UHF, NORM1_UHF_X, W_HF_MALTA, W_HF_MALTA_X,
     W_MF_MALTA, W_MF_MALTA_X, W_UHF_MALTA, W_UHF_MALTA_X, WMUL,
@@ -13,6 +12,8 @@ use crate::malta::malta_diff_map;
 use crate::mask::compute_mask_from_hf_uhf;
 use crate::opsin::linear_rgb_to_xyb_butteraugli;
 use crate::psycho::{PsychoImage, separate_frequencies};
+use crate::{ButteraugliError, ButteraugliParams};
+use enough::Stop;
 use imgref::ImgRef;
 use rgb::{RGB, RGB8};
 
@@ -722,29 +723,52 @@ pub fn compute_butteraugli_impl(
     let linear1 = srgb_u8_to_linear_f32(rgb1);
     let linear2 = srgb_u8_to_linear_f32(rgb2);
 
-    compute_butteraugli_linear_impl(&linear1, &linear2, width, height, params)
+    // Test-only helper: no cancellation token, so `Unstoppable` (which never
+    // returns `Err`) makes the `Result` infallible here.
+    compute_butteraugli_linear_impl(
+        &linear1,
+        &linear2,
+        width,
+        height,
+        params,
+        &enough::Unstoppable,
+    )
+    .expect("Unstoppable never cancels")
 }
 
 /// Main implementation of butteraugli comparison (linear RGB f32 input).
 ///
 /// This matches the C++ butteraugli API which expects linear RGB float input.
+///
+/// This is the core compute orchestrator: it dispatches the multi-scale
+/// work (single-resolution for small images, full-res + one half-res
+/// sub-level otherwise). The cooperative-cancellation check lives here, at
+/// the outermost scale-iteration boundary — *before* any scale's processing
+/// block — so a `cancel()` between strips / before a one-shot compare is
+/// honoured without ever entering the per-pixel kernels in
+/// `psycho`/`blur`/`malta`/`mask`/`opsin`. Those inner loops carry no check.
 pub fn compute_butteraugli_linear_impl(
     rgb1: &[f32],
     rgb2: &[f32],
     width: usize,
     height: usize,
     params: &ButteraugliParams,
-) -> InternalResult {
+    stop: &dyn Stop,
+) -> Result<InternalResult, ButteraugliError> {
     assert_eq!(rgb1.len(), width * height * 3);
     assert_eq!(rgb2.len(), width * height * 3);
 
+    // Cooperative cancellation: outermost per-scale (one-shot) boundary —
+    // checked before the scale dispatch below, never inside the kernels.
+    stop.check().map_err(ButteraugliError::Cancelled)?;
+
     // Handle identical images case
     if rgb1 == rgb2 {
-        return InternalResult {
+        return Ok(InternalResult {
             score: 0.0,
             pnorm_3: 0.0,
             diffmap: Some(ImageF::new(width, height)),
-        };
+        });
     }
 
     // Handle very small images without multi-resolution
@@ -757,11 +781,11 @@ pub fn compute_butteraugli_linear_impl(
     // Single-pass reduction: max-norm score AND libjxl 3-norm
     let (score, pnorm_3) = compute_score_from_diffmap(&diffmap);
 
-    InternalResult {
+    Ok(InternalResult {
         score,
         pnorm_3,
         diffmap: Some(diffmap),
-    }
+    })
 }
 
 /// Implementation of butteraugli comparison for ImgRef<RGB8>.
@@ -770,7 +794,8 @@ pub(crate) fn compute_butteraugli_imgref(
     img2: ImgRef<RGB8>,
     params: &ButteraugliParams,
     compute_diffmap: bool,
-) -> InternalResult {
+    stop: &dyn Stop,
+) -> Result<InternalResult, ButteraugliError> {
     let width = img1.width();
     let height = img1.height();
 
@@ -779,13 +804,14 @@ pub(crate) fn compute_butteraugli_imgref(
     let linear1 = imgref_srgb_to_linear_f32(img1);
     let linear2 = imgref_srgb_to_linear_f32(img2);
 
-    let mut result = compute_butteraugli_linear_impl(&linear1, &linear2, width, height, params);
+    let mut result =
+        compute_butteraugli_linear_impl(&linear1, &linear2, width, height, params, stop)?;
 
     if !compute_diffmap {
         result.diffmap = None;
     }
 
-    result
+    Ok(result)
 }
 
 /// Converts ImgRef<RGB8> directly to interleaved linear f32, skipping
@@ -811,7 +837,8 @@ pub(crate) fn compute_butteraugli_linear_imgref(
     img2: ImgRef<RGB<f32>>,
     params: &ButteraugliParams,
     compute_diffmap: bool,
-) -> InternalResult {
+    stop: &dyn Stop,
+) -> Result<InternalResult, ButteraugliError> {
     let width = img1.width();
     let height = img1.height();
 
@@ -820,14 +847,14 @@ pub(crate) fn compute_butteraugli_linear_imgref(
     let rgb2 = imgref_rgbf32_to_f32_vec(img2);
 
     // Use the existing proven implementation with multiresolution support
-    let mut result = compute_butteraugli_linear_impl(&rgb1, &rgb2, width, height, params);
+    let mut result = compute_butteraugli_linear_impl(&rgb1, &rgb2, width, height, params, stop)?;
 
     // Drop diffmap if not requested
     if !compute_diffmap {
         result.diffmap = None;
     }
 
-    result
+    Ok(result)
 }
 
 /// Converts ImgRef<RGB<f32>> to a contiguous Vec<f32> in RGB order.

--- a/butteraugli/src/lib.rs
+++ b/butteraugli/src/lib.rs
@@ -163,6 +163,7 @@ mod strip;
 pub use strip::{
     ButteraugliStripConfig, HALO_ROWS_DEFAULT, MIN_STRIP_HEIGHT, butteraugli_linear_strip,
     butteraugli_linear_strip_with_config, butteraugli_strip, butteraugli_strip_with_config,
+    butteraugli_strip_with_stop,
 };
 
 #[cfg(feature = "internals")]
@@ -173,6 +174,12 @@ pub(crate) mod psycho;
 // Re-export imgref and rgb types for convenience
 pub use imgref::{Img, ImgRef, ImgVec};
 pub use rgb::{RGB, RGB8};
+
+/// Re-export of the [`enough`] cooperative-cancellation crate, so callers of
+/// the `*_with_stop` entry points (e.g. [`butteraugli_with_stop`]) can name
+/// [`enough::Stop`] / [`enough::Unstoppable`] / [`enough::StopReason`]
+/// without taking a direct dependency.
+pub use enough;
 
 /// Reflect-101 index map (OpenCV `BORDER_REFLECT_101`): fold an
 /// out-of-range index `i` back into `[0, n)` by mirroring at the borders
@@ -300,6 +307,11 @@ pub enum ButteraugliError {
     },
     /// Score computation produced NaN or infinity (usually from non-finite input pixels).
     NonFiniteResult,
+    /// The computation was cooperatively cancelled via the
+    /// [`enough::Stop`] token passed to a `*_with_stop` entry point
+    /// (e.g. [`butteraugli_with_stop`]). Carries the
+    /// [`enough::StopReason`] (cancelled vs. timed out).
+    Cancelled(enough::StopReason),
 }
 
 impl std::fmt::Display for ButteraugliError {
@@ -332,6 +344,9 @@ impl std::fmt::Display for ButteraugliError {
                     f,
                     "image dimensions {width}x{height} overflow buffer size calculation"
                 )
+            }
+            Self::Cancelled(reason) => {
+                write!(f, "butteraugli computation cancelled: {reason}")
             }
             Self::NonFiniteResult => {
                 write!(
@@ -655,6 +670,38 @@ pub fn butteraugli(
     img2: ImgRef<RGB8>,
     params: &ButteraugliParams,
 ) -> Result<ButteraugliResult, ButteraugliError> {
+    butteraugli_with_stop(img1, img2, params, &enough::Unstoppable)
+}
+
+/// Like [`butteraugli`], but cooperatively cancellable via an
+/// [`enough::Stop`] token.
+///
+/// `stop` is checked once at the outermost per-scale boundary of the core
+/// compute (before any of the multi-scale processing blocks run); the
+/// per-pixel kernels are never interrupted mid-scale. If the token signals a
+/// stop, returns [`ButteraugliError::Cancelled`] carrying the
+/// [`enough::StopReason`].
+///
+/// Pass [`enough::Unstoppable`] for a non-cancellable call (this is exactly
+/// what [`butteraugli`] does — it is zero-cost).
+///
+/// # Arguments
+/// * `img1` - First image (sRGB, supports stride via ImgRef)
+/// * `img2` - Second image (sRGB, supports stride via ImgRef)
+/// * `params` - Comparison parameters
+/// * `stop` - Cooperative-cancellation token
+///
+/// # Errors
+/// Returns an error if:
+/// - Image dimensions don't match
+/// - Either dimension is zero
+/// - `stop` signals cancellation ([`ButteraugliError::Cancelled`])
+pub fn butteraugli_with_stop(
+    img1: ImgRef<RGB8>,
+    img2: ImgRef<RGB8>,
+    params: &ButteraugliParams,
+    stop: &dyn enough::Stop,
+) -> Result<ButteraugliResult, ButteraugliError> {
     params.validate()?;
 
     let (w1, h1) = (img1.width(), img1.height());
@@ -695,7 +742,7 @@ pub fn butteraugli(
         _ => (img1, img2),
     };
 
-    let result = diff::compute_butteraugli_imgref(i1, i2, params, params.compute_diffmap);
+    let result = diff::compute_butteraugli_imgref(i1, i2, params, params.compute_diffmap, stop)?;
 
     if !result.score.is_finite() {
         return Err(ButteraugliError::NonFiniteResult);
@@ -746,6 +793,39 @@ pub fn butteraugli_linear(
     img2: ImgRef<RGB<f32>>,
     params: &ButteraugliParams,
 ) -> Result<ButteraugliResult, ButteraugliError> {
+    butteraugli_linear_with_stop(img1, img2, params, &enough::Unstoppable)
+}
+
+/// Like [`butteraugli_linear`], but cooperatively cancellable via an
+/// [`enough::Stop`] token.
+///
+/// `stop` is checked once at the outermost per-scale boundary of the core
+/// compute (before any of the multi-scale processing blocks run); the
+/// per-pixel kernels are never interrupted mid-scale. If the token signals a
+/// stop, returns [`ButteraugliError::Cancelled`] carrying the
+/// [`enough::StopReason`].
+///
+/// Pass [`enough::Unstoppable`] for a non-cancellable call (this is exactly
+/// what [`butteraugli_linear`] does — it is zero-cost).
+///
+/// # Arguments
+/// * `img1` - First image (linear RGB, `1.0` = `intensity_target` nits)
+/// * `img2` - Second image (linear RGB, `1.0` = `intensity_target` nits)
+/// * `params` - Comparison parameters
+/// * `stop` - Cooperative-cancellation token
+///
+/// # Errors
+/// Returns an error if:
+/// - Image dimensions don't match
+/// - Either dimension is zero
+/// - Any input pixel is NaN or infinite
+/// - `stop` signals cancellation ([`ButteraugliError::Cancelled`])
+pub fn butteraugli_linear_with_stop(
+    img1: ImgRef<RGB<f32>>,
+    img2: ImgRef<RGB<f32>>,
+    params: &ButteraugliParams,
+    stop: &dyn enough::Stop,
+) -> Result<ButteraugliResult, ButteraugliError> {
     params.validate()?;
 
     let (w1, h1) = (img1.width(), img1.height());
@@ -784,7 +864,8 @@ pub fn butteraugli_linear(
         _ => (img1, img2),
     };
 
-    let result = diff::compute_butteraugli_linear_imgref(i1, i2, params, params.compute_diffmap);
+    let result =
+        diff::compute_butteraugli_linear_imgref(i1, i2, params, params.compute_diffmap, stop)?;
 
     if !result.score.is_finite() {
         return Err(ButteraugliError::NonFiniteResult);

--- a/butteraugli/src/precompute.rs
+++ b/butteraugli/src/precompute.rs
@@ -25,6 +25,8 @@
 //! }
 //! ```
 
+use enough::Stop;
+
 use crate::diff::maybe_join;
 use crate::image::{BufferPool, Image3F, ImageF};
 use crate::mask::PrecomputedMask;
@@ -438,6 +440,24 @@ impl ButteraugliReference {
     /// Returns an error if:
     /// - Buffer size doesn't match reference dimensions
     pub fn compare(&self, rgb: &[u8]) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_with_stop(rgb, &enough::Unstoppable)
+    }
+
+    /// Cancellable variant of [`Self::compare`].
+    ///
+    /// `stop` is checked once at the outermost per-scale boundary of the
+    /// warm-reference compute, before any per-pixel work; a cancelled token
+    /// returns [`ButteraugliError::Cancelled`]. [`enough::Unstoppable`] makes
+    /// this behave identically to [`Self::compare`] at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare`], plus [`ButteraugliError::Cancelled`] if `stop`
+    /// signals cancellation.
+    pub fn compare_with_stop(
+        &self,
+        rgb: &[u8],
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         let expected_size = self.width * self.height * 3;
 
         if rgb.len() != expected_size {
@@ -447,7 +467,7 @@ impl ButteraugliReference {
             });
         }
 
-        let result = self.compare_impl(rgb);
+        let result = self.compare_impl(rgb, stop)?;
         if !result.score.is_finite() {
             return Err(ButteraugliError::NonFiniteResult);
         }
@@ -463,6 +483,24 @@ impl ButteraugliReference {
     /// Returns an error if:
     /// - Buffer size doesn't match reference dimensions
     pub fn compare_linear(&self, rgb: &[f32]) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_linear_with_stop(rgb, &enough::Unstoppable)
+    }
+
+    /// Cancellable variant of [`Self::compare_linear`].
+    ///
+    /// `stop` is checked once at the outermost per-scale boundary of the
+    /// warm-reference compute, before any per-pixel work; a cancelled token
+    /// returns [`ButteraugliError::Cancelled`]. [`enough::Unstoppable`] makes
+    /// this behave identically to [`Self::compare_linear`] at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_linear`], plus [`ButteraugliError::Cancelled`] if
+    /// `stop` signals cancellation.
+    pub fn compare_linear_with_stop(
+        &self,
+        rgb: &[f32],
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         let expected_size = self.width * self.height * 3;
 
         if rgb.len() != expected_size {
@@ -474,7 +512,7 @@ impl ButteraugliReference {
 
         check_finite_f32(rgb, "compare linear rgb")?;
 
-        let result = self.compare_linear_impl(rgb);
+        let result = self.compare_linear_impl(rgb, stop)?;
         if !result.score.is_finite() {
             return Err(ButteraugliError::NonFiniteResult);
         }
@@ -520,7 +558,8 @@ impl ButteraugliReference {
         check_finite_f32(&g[..min_size], "compare planar g")?;
         check_finite_f32(&b[..min_size], "compare planar b")?;
 
-        let result = self.compare_linear_planar_impl(r, g, b, stride);
+        // Non-cancellable entry point — `Unstoppable` is zero-cost.
+        let result = self.compare_linear_planar_impl(r, g, b, stride, &enough::Unstoppable)?;
         if !result.score.is_finite() {
             return Err(ButteraugliError::NonFiniteResult);
         }
@@ -573,7 +612,15 @@ impl ButteraugliReference {
         check_finite_f32(&g[..min_size], "compare planar g")?;
         check_finite_f32(&b[..min_size], "compare planar b")?;
 
-        let (score, pnorm_3) = self.compare_linear_planar_impl_into(r, g, b, stride, diffmap_out);
+        // Non-cancellable entry point — `Unstoppable` is zero-cost.
+        let (score, pnorm_3) = self.compare_linear_planar_impl_into(
+            r,
+            g,
+            b,
+            stride,
+            diffmap_out,
+            &enough::Unstoppable,
+        )?;
         if !score.is_finite() {
             return Err(ButteraugliError::NonFiniteResult);
         }
@@ -723,6 +770,24 @@ impl ButteraugliReference {
         &self,
         img: imgref::ImgRef<rgb::RGB8>,
     ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_srgb_with_stop(img, &enough::Unstoppable)
+    }
+
+    /// Cancellable variant of [`Self::compare_srgb`].
+    ///
+    /// `stop` is checked once at the outermost per-scale boundary of the
+    /// warm-reference compute, before any per-pixel work; a cancelled token
+    /// returns [`ButteraugliError::Cancelled`]. [`enough::Unstoppable`] makes
+    /// this behave identically to [`Self::compare_srgb`] at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_srgb`], plus [`ButteraugliError::Cancelled`] if
+    /// `stop` signals cancellation.
+    pub fn compare_srgb_with_stop(
+        &self,
+        img: imgref::ImgRef<rgb::RGB8>,
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         if img.width() != self.width || img.height() != self.height {
             return Err(ButteraugliError::DimensionMismatch {
                 w1: self.width,
@@ -732,7 +797,7 @@ impl ButteraugliReference {
             });
         }
         let linear = crate::diff::imgref_srgb_to_linear_f32(img);
-        self.compare_linear(&linear)
+        self.compare_linear_with_stop(&linear, stop)
     }
 
     /// Compare a distorted linear RGB image (as `ImgRef<RGB<f32>>`) against the reference.
@@ -743,6 +808,24 @@ impl ButteraugliReference {
         &self,
         img: imgref::ImgRef<rgb::RGB<f32>>,
     ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_linear_imgref_with_stop(img, &enough::Unstoppable)
+    }
+
+    /// Cancellable variant of [`Self::compare_linear_imgref`].
+    ///
+    /// `stop` is checked once at the outermost per-scale boundary of the
+    /// warm-reference compute, before any per-pixel work; a cancelled token
+    /// returns [`ButteraugliError::Cancelled`]. [`enough::Unstoppable`] makes
+    /// this behave identically to [`Self::compare_linear_imgref`] at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_linear_imgref`], plus [`ButteraugliError::Cancelled`]
+    /// if `stop` signals cancellation.
+    pub fn compare_linear_imgref_with_stop(
+        &self,
+        img: imgref::ImgRef<rgb::RGB<f32>>,
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         if img.width() != self.width || img.height() != self.height {
             return Err(ButteraugliError::DimensionMismatch {
                 w1: self.width,
@@ -752,15 +835,19 @@ impl ButteraugliReference {
             });
         }
         let rgb = crate::diff::imgref_rgbf32_to_f32_vec(img);
-        self.compare_linear(&rgb)
+        self.compare_linear_with_stop(&rgb, stop)
     }
 
     /// Internal comparison implementation for sRGB input.
     ///
     /// Converts sRGB to linear and delegates to the linear path.
-    fn compare_impl(&self, rgb: &[u8]) -> ButteraugliResult {
+    fn compare_impl(
+        &self,
+        rgb: &[u8],
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         let linear = srgb_u8_to_linear_f32(rgb);
-        self.compare_linear_impl(&linear)
+        self.compare_linear_impl(&linear, stop)
     }
 
     /// Internal comparison implementation for linear RGB input.
@@ -768,7 +855,21 @@ impl ButteraugliReference {
     /// Computes full-resolution diffmap using precomputed reference, then adds
     /// a single half-resolution sub-level via AddSupersampled2x. This matches
     /// C++ `ButteraugliComparator::Diffmap` which only uses one sub-level.
-    fn compare_linear_impl(&self, rgb: &[f32]) -> ButteraugliResult {
+    ///
+    /// The cooperative-cancellation check lives here, at the outermost
+    /// per-scale boundary — *before* the full-res + half-res scale dispatch
+    /// (`maybe_join`) below — so a `cancel()` between warm-ref compares is
+    /// honoured without ever entering the per-pixel kernels in
+    /// `opsin`/`psycho`/`mask`/`malta`/`blur`. Those inner loops carry no check.
+    fn compare_linear_impl(
+        &self,
+        rgb: &[f32],
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
+        // Cooperative cancellation: outermost per-scale boundary — checked
+        // before the scale dispatch below, never inside the kernels.
+        stop.check().map_err(ButteraugliError::Cancelled)?;
+
         let intensity_target = self.params.intensity_target();
         let width = self.width;
         let height = self.height;
@@ -818,11 +919,11 @@ impl ButteraugliReference {
 
         let (score, pnorm_3) = compute_score_from_diffmap(&diffmap);
 
-        ButteraugliResult {
+        Ok(ButteraugliResult {
             score,
             pnorm_3,
             diffmap: Some(diffmap.into_imgvec()),
-        }
+        })
     }
 
     /// Internal comparison implementation for planar linear RGB input,
@@ -838,7 +939,12 @@ impl ButteraugliReference {
         b: &[f32],
         stride: usize,
         diffmap_out: &mut Vec<f32>,
-    ) -> (f64, f64) {
+        stop: &dyn Stop,
+    ) -> Result<(f64, f64), ButteraugliError> {
+        // Cooperative cancellation: outermost per-scale boundary — checked
+        // before the scale dispatch below, never inside the kernels.
+        stop.check().map_err(ButteraugliError::Cancelled)?;
+
         let intensity_target = self.params.intensity_target();
         let width = self.width;
         let height = self.height;
@@ -929,7 +1035,7 @@ impl ButteraugliReference {
         }
         diffmap.recycle(pool);
 
-        (score, pnorm_3)
+        Ok((score, pnorm_3))
     }
 
     /// Internal comparison implementation for planar linear RGB input.
@@ -939,7 +1045,12 @@ impl ButteraugliReference {
         g: &[f32],
         b: &[f32],
         stride: usize,
-    ) -> ButteraugliResult {
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
+        // Cooperative cancellation: outermost per-scale boundary — checked
+        // before the scale dispatch below, never inside the kernels.
+        stop.check().map_err(ButteraugliError::Cancelled)?;
+
         let intensity_target = self.params.intensity_target();
         let width = self.width;
         let height = self.height;
@@ -1009,11 +1120,11 @@ impl ButteraugliReference {
 
         let (score, pnorm_3) = compute_score_from_diffmap(&diffmap);
 
-        ButteraugliResult {
+        Ok(ButteraugliResult {
             score,
             pnorm_3,
             diffmap: Some(diffmap.into_imgvec()),
-        }
+        })
     }
 }
 

--- a/butteraugli/src/strip.rs
+++ b/butteraugli/src/strip.rs
@@ -66,6 +66,7 @@
 //! # Ok::<(), butteraugli::ButteraugliError>(())
 //! ```
 
+use enough::Stop;
 use imgref::ImgRef;
 use rgb::{RGB, RGB8};
 
@@ -238,6 +239,38 @@ pub fn butteraugli_strip(
     )
 }
 
+/// Like [`butteraugli_strip`], but cooperatively cancellable via an
+/// [`enough::Stop`] token.
+///
+/// `stop` is checked once per strip, at the top of the strip loop (the
+/// outermost per-strip boundary); the per-strip diffmap kernels are never
+/// interrupted mid-strip. If the token signals a stop, returns
+/// [`ButteraugliError::Cancelled`] carrying the [`enough::StopReason`].
+///
+/// Pass [`enough::Unstoppable`] for a non-cancellable call (this is exactly
+/// what [`butteraugli_strip`] does — it is zero-cost). Uses the default
+/// strip config (halo = [`HALO_ROWS_DEFAULT`]).
+///
+/// # Errors
+/// As [`butteraugli_strip`], plus [`ButteraugliError::Cancelled`] if `stop`
+/// signals cancellation.
+pub fn butteraugli_strip_with_stop(
+    img1: ImgRef<RGB8>,
+    img2: ImgRef<RGB8>,
+    params: &ButteraugliParams,
+    strip_height: u32,
+    stop: &dyn Stop,
+) -> Result<ButteraugliResult, ButteraugliError> {
+    butteraugli_strip_with_config_and_stop(
+        img1,
+        img2,
+        params,
+        strip_height,
+        ButteraugliStripConfig::default(),
+        stop,
+    )
+}
+
 /// Strip-wise butteraugli with sRGB u8 inputs and explicit
 /// configuration.
 ///
@@ -249,6 +282,26 @@ pub fn butteraugli_strip_with_config(
     params: &ButteraugliParams,
     strip_height: u32,
     config: ButteraugliStripConfig,
+) -> Result<ButteraugliResult, ButteraugliError> {
+    butteraugli_strip_with_config_and_stop(
+        img1,
+        img2,
+        params,
+        strip_height,
+        config,
+        &enough::Unstoppable,
+    )
+}
+
+/// Shared body for the sRGB strip entry points; `stop` is threaded to the
+/// strip walker which checks it once per strip.
+fn butteraugli_strip_with_config_and_stop(
+    img1: ImgRef<RGB8>,
+    img2: ImgRef<RGB8>,
+    params: &ButteraugliParams,
+    strip_height: u32,
+    config: ButteraugliStripConfig,
+    stop: &dyn Stop,
 ) -> Result<ButteraugliResult, ButteraugliError> {
     params.validate()?;
     validate_image_pair(img1, img2, strip_height as usize)?;
@@ -271,6 +324,7 @@ pub fn butteraugli_strip_with_config(
         params,
         config.halo_rows,
         params.compute_diffmap(),
+        stop,
     )
 }
 
@@ -335,6 +389,7 @@ pub fn butteraugli_linear_strip_with_config(
     check_finite_f32(&linear1, "linear rgb1")?;
     check_finite_f32(&linear2, "linear rgb2")?;
 
+    // No cancellation token on this entry point — `Unstoppable` is zero-cost.
     run_strip_walker_linear(
         &linear1,
         &linear2,
@@ -344,6 +399,7 @@ pub fn butteraugli_linear_strip_with_config(
         params,
         config.halo_rows,
         params.compute_diffmap(),
+        &enough::Unstoppable,
     )
 }
 
@@ -376,6 +432,10 @@ fn validate_image_pair(
 /// buffer for each strip, calls the existing diffmap path on the
 /// strip's rows (with halo), accumulates the strip's interior into a
 /// single max + p-norm reducer, and produces the final score.
+///
+/// `stop` is checked once per strip, at the top of the strip loop (the
+/// outermost per-strip boundary) — never inside the per-strip diffmap
+/// kernels. A `cancel()` is therefore honoured at strip granularity.
 #[allow(clippy::too_many_arguments)]
 fn run_strip_walker_linear(
     rgb1: &[f32],
@@ -386,6 +446,7 @@ fn run_strip_walker_linear(
     params: &ButteraugliParams,
     halo: usize,
     want_diffmap: bool,
+    stop: &dyn Stop,
 ) -> Result<ButteraugliResult, ButteraugliError> {
     let mut full_diffmap: Option<Vec<f32>> = if want_diffmap {
         Some(vec![0.0; width * height])
@@ -396,6 +457,10 @@ fn run_strip_walker_linear(
 
     let mut y = 0usize;
     while y < height {
+        // Cooperative cancellation: outermost per-strip boundary — checked
+        // before this strip's diffmap is computed, never inside the kernels.
+        stop.check().map_err(ButteraugliError::Cancelled)?;
+
         let mut next_y = (y + strip_height).next_multiple_of(STRIP_ALIGNMENT);
         if next_y >= height || height - next_y < STRIP_ALIGNMENT {
             next_y = height;
@@ -490,6 +555,31 @@ impl ButteraugliReference {
         self.compare_strip_with_config(rgb, strip_height, ButteraugliStripConfig::default())
     }
 
+    /// Cancellable variant of [`Self::compare_strip`].
+    ///
+    /// `stop` is checked once per strip, at the outermost per-strip boundary
+    /// of the strip walker, before that strip's diffmap is computed; a
+    /// cancelled token returns [`ButteraugliError::Cancelled`].
+    /// [`enough::Unstoppable`] makes this behave identically to
+    /// [`Self::compare_strip`] at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_strip`], plus [`ButteraugliError::Cancelled`] if
+    /// `stop` signals cancellation between strips.
+    pub fn compare_strip_with_stop(
+        &self,
+        rgb: &[u8],
+        strip_height: u32,
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_strip_with_config_and_stop(
+            rgb,
+            strip_height,
+            ButteraugliStripConfig::default(),
+            stop,
+        )
+    }
+
     /// Strip-bounded comparison with explicit configuration.
     ///
     /// # Errors
@@ -499,6 +589,23 @@ impl ButteraugliReference {
         rgb: &[u8],
         strip_height: u32,
         config: ButteraugliStripConfig,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_strip_with_config_and_stop(rgb, strip_height, config, &enough::Unstoppable)
+    }
+
+    /// Shared body for the sRGB strip entry points; `stop` is threaded to the
+    /// strip walker (checked once per strip). The non-cancellable entry points
+    /// pass [`enough::Unstoppable`].
+    ///
+    /// # Errors
+    /// As [`ButteraugliReference::compare_strip`], plus
+    /// [`ButteraugliError::Cancelled`] if `stop` signals cancellation.
+    fn compare_strip_with_config_and_stop(
+        &self,
+        rgb: &[u8],
+        strip_height: u32,
+        config: ButteraugliStripConfig,
+        stop: &dyn Stop,
     ) -> Result<ButteraugliResult, ButteraugliError> {
         let width = self.width();
         let height = self.height();
@@ -534,6 +641,8 @@ impl ButteraugliReference {
         let lut = &*crate::opsin::SRGB_TO_LINEAR_LUT;
         let linear2: Vec<f32> = rgb.iter().map(|&v| lut[v as usize]).collect();
 
+        // `stop` is checked once per strip inside the walker; non-cancellable
+        // callers pass `Unstoppable` (zero-cost).
         run_strip_walker_linear(
             &linear1,
             &linear2,
@@ -543,6 +652,7 @@ impl ButteraugliReference {
             self.params(),
             config.halo_rows,
             self.params().compute_diffmap(),
+            stop,
         )
     }
 
@@ -559,6 +669,31 @@ impl ButteraugliReference {
         self.compare_linear_strip_with_config(rgb, strip_height, ButteraugliStripConfig::default())
     }
 
+    /// Cancellable variant of [`Self::compare_linear_strip`].
+    ///
+    /// `stop` is checked once per strip, at the outermost per-strip boundary
+    /// of the strip walker, before that strip's diffmap is computed; a
+    /// cancelled token returns [`ButteraugliError::Cancelled`].
+    /// [`enough::Unstoppable`] makes this behave identically to
+    /// [`Self::compare_linear_strip`] at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_linear_strip`], plus [`ButteraugliError::Cancelled`]
+    /// if `stop` signals cancellation between strips.
+    pub fn compare_linear_strip_with_stop(
+        &self,
+        rgb: &[f32],
+        strip_height: u32,
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_linear_strip_with_config_and_stop(
+            rgb,
+            strip_height,
+            ButteraugliStripConfig::default(),
+            stop,
+        )
+    }
+
     /// Strip-bounded linear-RGB comparison with explicit configuration.
     ///
     /// # Errors
@@ -568,6 +703,28 @@ impl ButteraugliReference {
         rgb: &[f32],
         strip_height: u32,
         config: ButteraugliStripConfig,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_linear_strip_with_config_and_stop(
+            rgb,
+            strip_height,
+            config,
+            &enough::Unstoppable,
+        )
+    }
+
+    /// Shared body for the linear-RGB strip entry points; `stop` is threaded
+    /// to the strip walker (checked once per strip). The non-cancellable entry
+    /// points pass [`enough::Unstoppable`].
+    ///
+    /// # Errors
+    /// As [`ButteraugliReference::compare_strip`], plus
+    /// [`ButteraugliError::Cancelled`] if `stop` signals cancellation.
+    fn compare_linear_strip_with_config_and_stop(
+        &self,
+        rgb: &[f32],
+        strip_height: u32,
+        config: ButteraugliStripConfig,
+        stop: &dyn Stop,
     ) -> Result<ButteraugliResult, ButteraugliError> {
         let width = self.width();
         let height = self.height();
@@ -596,6 +753,8 @@ impl ButteraugliReference {
                      constructor does not retain interleaved source data, \
                      and `drop_strip_source` was not previously called)",
             })?;
+        // `stop` is checked once per strip inside the walker; non-cancellable
+        // callers pass `Unstoppable` (zero-cost).
         run_strip_walker_linear(
             &linear1,
             rgb,
@@ -605,6 +764,7 @@ impl ButteraugliReference {
             self.params(),
             config.halo_rows,
             self.params().compute_diffmap(),
+            stop,
         )
     }
 
@@ -618,6 +778,25 @@ impl ButteraugliReference {
         img: ImgRef<RGB8>,
         strip_height: u32,
     ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_strip_srgb_with_stop(img, strip_height, &enough::Unstoppable)
+    }
+
+    /// Cancellable variant of [`Self::compare_strip_srgb`].
+    ///
+    /// `stop` is checked once per strip inside the strip walker; a cancelled
+    /// token returns [`ButteraugliError::Cancelled`]. [`enough::Unstoppable`]
+    /// makes this behave identically to [`Self::compare_strip_srgb`] at zero
+    /// cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_strip_srgb`], plus [`ButteraugliError::Cancelled`]
+    /// if `stop` signals cancellation between strips.
+    pub fn compare_strip_srgb_with_stop(
+        &self,
+        img: ImgRef<RGB8>,
+        strip_height: u32,
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         if img.width() != self.width() || img.height() != self.height() {
             return Err(ButteraugliError::DimensionMismatch {
                 w1: self.width(),
@@ -627,7 +806,7 @@ impl ButteraugliReference {
             });
         }
         let linear = imgref_srgb_to_linear_f32(img);
-        self.compare_linear_strip(&linear, strip_height)
+        self.compare_linear_strip_with_stop(&linear, strip_height, stop)
     }
 
     /// Compare a distorted linear-RGB image (as `ImgRef<RGB<f32>>`)
@@ -640,6 +819,26 @@ impl ButteraugliReference {
         img: ImgRef<RGB<f32>>,
         strip_height: u32,
     ) -> Result<ButteraugliResult, ButteraugliError> {
+        self.compare_strip_linear_imgref_with_stop(img, strip_height, &enough::Unstoppable)
+    }
+
+    /// Cancellable variant of [`Self::compare_strip_linear_imgref`].
+    ///
+    /// `stop` is checked once per strip inside the strip walker; a cancelled
+    /// token returns [`ButteraugliError::Cancelled`]. [`enough::Unstoppable`]
+    /// makes this behave identically to [`Self::compare_strip_linear_imgref`]
+    /// at zero cost.
+    ///
+    /// # Errors
+    /// As [`Self::compare_strip_linear_imgref`], plus
+    /// [`ButteraugliError::Cancelled`] if `stop` signals cancellation between
+    /// strips.
+    pub fn compare_strip_linear_imgref_with_stop(
+        &self,
+        img: ImgRef<RGB<f32>>,
+        strip_height: u32,
+        stop: &dyn Stop,
+    ) -> Result<ButteraugliResult, ButteraugliError> {
         if img.width() != self.width() || img.height() != self.height() {
             return Err(ButteraugliError::DimensionMismatch {
                 w1: self.width(),
@@ -650,6 +849,6 @@ impl ButteraugliReference {
         }
         let linear = imgref_rgbf32_to_f32_vec(img);
         check_finite_f32(&linear, "linear rgb")?;
-        self.compare_linear_strip(&linear, strip_height)
+        self.compare_linear_strip_with_stop(&linear, strip_height, stop)
     }
 }

--- a/butteraugli/tests/cancellation.rs
+++ b/butteraugli/tests/cancellation.rs
@@ -1,0 +1,272 @@
+//! Cooperative-cancellation tests for the `*_with_stop` entry points.
+//!
+//! A pre-cancelled [`almost_enough::Stopper::cancelled`] token must make every
+//! `*_with_stop` function bail out with [`ButteraugliError::Cancelled`] at its
+//! outermost per-scale / per-strip boundary, *before* doing any per-pixel work.
+//! An [`enough::Unstoppable`] token must leave the result untouched (`Ok`).
+
+use butteraugli::{
+    ButteraugliError, ButteraugliParams, ButteraugliReference, Img, RGB, RGB8,
+    butteraugli_linear_with_stop, butteraugli_strip_with_stop, butteraugli_with_stop,
+};
+
+/// Small deterministic sRGB test image (≥8×8 so the strip API accepts it).
+fn srgb_image(width: usize, height: usize, seed: usize) -> Img<Vec<RGB8>> {
+    let pixels: Vec<RGB8> = (0..width * height)
+        .map(|i| {
+            let v = i + seed;
+            RGB8::new(
+                (v % 256) as u8,
+                ((v * 2) % 256) as u8,
+                ((v * 3) % 256) as u8,
+            )
+        })
+        .collect();
+    Img::new(pixels, width, height)
+}
+
+/// Flat row-major RGB `u8` bytes (3 per pixel) for the warm-reference
+/// `ButteraugliReference::new` / `compare*` byte-slice entry points.
+fn srgb_bytes(width: usize, height: usize, seed: usize) -> Vec<u8> {
+    (0..width * height)
+        .flat_map(|i| {
+            let v = i + seed;
+            [
+                (v % 256) as u8,
+                ((v * 2) % 256) as u8,
+                ((v * 3) % 256) as u8,
+            ]
+        })
+        .collect()
+}
+
+/// Same content as [`srgb_image`] but as linear-RGB f32 (cheap stand-in — the
+/// cancellation check fires before any opsin/scaling work runs).
+fn linear_image(width: usize, height: usize, seed: usize) -> Img<Vec<RGB<f32>>> {
+    let pixels: Vec<RGB<f32>> = (0..width * height)
+        .map(|i| {
+            let v = (i + seed) as f32;
+            RGB::new(
+                (v % 256.0) / 255.0,
+                ((v * 2.0) % 256.0) / 255.0,
+                ((v * 3.0) % 256.0) / 255.0,
+            )
+        })
+        .collect();
+    Img::new(pixels, width, height)
+}
+
+#[test]
+fn butteraugli_with_stop_cancelled() {
+    let a = srgb_image(16, 16, 0);
+    let b = srgb_image(16, 16, 5);
+    let params = ButteraugliParams::default();
+
+    let result = butteraugli_with_stop(
+        a.as_ref(),
+        b.as_ref(),
+        &params,
+        &almost_enough::Stopper::cancelled(),
+    );
+
+    assert!(
+        matches!(result, Err(ButteraugliError::Cancelled(_))),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[test]
+fn butteraugli_with_stop_unstoppable_ok() {
+    let a = srgb_image(16, 16, 0);
+    let b = srgb_image(16, 16, 5);
+    let params = ButteraugliParams::default();
+
+    let result = butteraugli_with_stop(a.as_ref(), b.as_ref(), &params, &enough::Unstoppable)
+        .expect("Unstoppable must not cancel");
+
+    assert!(result.score.is_finite());
+    // Distinct images must produce a non-zero score (sanity: real work ran).
+    assert!(
+        result.score > 0.0,
+        "expected non-zero score, got {}",
+        result.score
+    );
+}
+
+#[test]
+fn butteraugli_with_stop_unstoppable_matches_butteraugli() {
+    // The Unstoppable path must be byte-for-byte the plain `butteraugli`.
+    let a = srgb_image(16, 16, 0);
+    let b = srgb_image(16, 16, 5);
+    let params = ButteraugliParams::default();
+
+    let plain = butteraugli::butteraugli(a.as_ref(), b.as_ref(), &params).unwrap();
+    let stopped =
+        butteraugli_with_stop(a.as_ref(), b.as_ref(), &params, &enough::Unstoppable).unwrap();
+
+    assert_eq!(plain.score, stopped.score);
+}
+
+#[test]
+fn butteraugli_linear_with_stop_cancelled() {
+    let a = linear_image(16, 16, 0);
+    let b = linear_image(16, 16, 5);
+    let params = ButteraugliParams::default();
+
+    let result = butteraugli_linear_with_stop(
+        a.as_ref(),
+        b.as_ref(),
+        &params,
+        &almost_enough::Stopper::cancelled(),
+    );
+
+    assert!(
+        matches!(result, Err(ButteraugliError::Cancelled(_))),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[test]
+fn butteraugli_linear_with_stop_unstoppable_ok() {
+    let a = linear_image(16, 16, 0);
+    let b = linear_image(16, 16, 5);
+    let params = ButteraugliParams::default();
+
+    let result =
+        butteraugli_linear_with_stop(a.as_ref(), b.as_ref(), &params, &enough::Unstoppable)
+            .expect("Unstoppable must not cancel");
+
+    assert!(result.score.is_finite());
+}
+
+#[test]
+fn butteraugli_strip_with_stop_cancelled() {
+    let a = srgb_image(32, 32, 0);
+    let b = srgb_image(32, 32, 5);
+    let params = ButteraugliParams::default();
+
+    let result = butteraugli_strip_with_stop(
+        a.as_ref(),
+        b.as_ref(),
+        &params,
+        16,
+        &almost_enough::Stopper::cancelled(),
+    );
+
+    assert!(
+        matches!(result, Err(ButteraugliError::Cancelled(_))),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[test]
+fn butteraugli_strip_with_stop_unstoppable_ok() {
+    let a = srgb_image(32, 32, 0);
+    let b = srgb_image(32, 32, 5);
+    let params = ButteraugliParams::default();
+
+    let result =
+        butteraugli_strip_with_stop(a.as_ref(), b.as_ref(), &params, 16, &enough::Unstoppable)
+            .expect("Unstoppable must not cancel");
+
+    assert!(result.score.is_finite());
+}
+
+#[test]
+fn butteraugli_strip_with_stop_unstoppable_matches_plain_strip() {
+    let a = srgb_image(32, 32, 0);
+    let b = srgb_image(32, 32, 5);
+    let params = ButteraugliParams::default();
+
+    let plain = butteraugli::butteraugli_strip(a.as_ref(), b.as_ref(), &params, 16).unwrap();
+    let stopped =
+        butteraugli_strip_with_stop(a.as_ref(), b.as_ref(), &params, 16, &enough::Unstoppable)
+            .unwrap();
+
+    assert_eq!(plain.score, stopped.score);
+}
+
+// ----------------------------------------------------------------------------
+// Warm-reference (`ButteraugliReference`) batch path.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn reference_compare_with_stop_cancelled() {
+    let reference =
+        ButteraugliReference::new(&srgb_bytes(16, 16, 0), 16, 16, ButteraugliParams::default())
+            .unwrap();
+    let dist = srgb_bytes(16, 16, 5);
+
+    let result = reference.compare_with_stop(&dist, &almost_enough::Stopper::cancelled());
+
+    assert!(
+        matches!(result, Err(ButteraugliError::Cancelled(_))),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[test]
+fn reference_compare_with_stop_unstoppable_ok() {
+    let reference =
+        ButteraugliReference::new(&srgb_bytes(16, 16, 0), 16, 16, ButteraugliParams::default())
+            .unwrap();
+    let dist = srgb_bytes(16, 16, 5);
+
+    let result = reference
+        .compare_with_stop(&dist, &enough::Unstoppable)
+        .expect("Unstoppable must not cancel");
+
+    assert!(result.score.is_finite());
+    // Distinct images must produce a non-zero score (sanity: real work ran).
+    assert!(
+        result.score > 0.0,
+        "expected non-zero score, got {}",
+        result.score
+    );
+}
+
+#[test]
+fn reference_compare_with_stop_unstoppable_matches_compare() {
+    // The Unstoppable warm-ref path must be byte-for-byte the plain `compare`.
+    let reference =
+        ButteraugliReference::new(&srgb_bytes(16, 16, 0), 16, 16, ButteraugliParams::default())
+            .unwrap();
+    let dist = srgb_bytes(16, 16, 5);
+
+    let plain = reference.compare(&dist).unwrap();
+    let stopped = reference
+        .compare_with_stop(&dist, &enough::Unstoppable)
+        .unwrap();
+
+    assert_eq!(plain.score, stopped.score);
+}
+
+#[test]
+fn reference_compare_strip_with_stop_cancelled() {
+    let reference =
+        ButteraugliReference::new(&srgb_bytes(32, 32, 0), 32, 32, ButteraugliParams::default())
+            .unwrap();
+    let dist = srgb_bytes(32, 32, 5);
+
+    let result = reference.compare_strip_with_stop(&dist, 16, &almost_enough::Stopper::cancelled());
+
+    assert!(
+        matches!(result, Err(ButteraugliError::Cancelled(_))),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[test]
+fn reference_compare_strip_with_stop_unstoppable_matches_plain() {
+    let reference =
+        ButteraugliReference::new(&srgb_bytes(32, 32, 0), 32, 32, ButteraugliParams::default())
+            .unwrap();
+    let dist = srgb_bytes(32, 32, 5);
+
+    let plain = reference.compare_strip(&dist, 16).unwrap();
+    let stopped = reference
+        .compare_strip_with_stop(&dist, 16, &enough::Unstoppable)
+        .expect("Unstoppable must not cancel");
+
+    assert_eq!(plain.score, stopped.score);
+}

--- a/docs/public-api/butteraugli.txt
+++ b/docs/public-api/butteraugli.txt
@@ -6,27 +6,27 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: butteraugli.txt 109 lines (supported surface) | butteraugli.features.txt 132 added (features: avx512,corpus-tests,iir-blur,internals,rayon,unsafe-performance) | butteraugli.internal.txt 9 lines (9 hidden + 0 excluded-feature)
+# files: butteraugli.txt 130 lines (supported surface) | butteraugli.features.txt 132 added (features: avx512,corpus-tests,iir-blur,internals,rayon,unsafe-performance) | butteraugli.internal.txt 9 lines (9 hidden + 0 excluded-feature)
 
 ## summary
 #
 #   pub modules                                 2
 #   pub types (struct/enum/trait/alias)         6
 #   pub consts/statics                          4
-#   free functions                              7
-#   inherent methods                           59
+#   free functions                             10
+#   inherent methods                           75
 #   struct fields                              15
-#   enum variants                               5
-#   re-exports                                  5
+#   enum variants                               6
+#   re-exports                                  6
 #   trait roster entries (type × trait)        15
 #   auto-trait-complete types                   4
 #   auto-trait exceptions                       1
 #
 # per-module pub lines:
-#   (root)                           58
-#   precompute                       45
+#   (root)                           63
+#   precompute                       61
 
-## items (102 lines)
+## items (123 lines)
 
 pub mod butteraugli
 pub use Img
@@ -34,13 +34,18 @@ pub use ImgRef
 pub use ImgVec
 pub use RGB
 pub use RGB8
+pub use enough
 pub mod precompute
 pub fn precompute::ButteraugliReference::compare(&self, &[u8]) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear(&self, &[f32]) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_imgref(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_linear_imgref_with_stop(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_planar(&self, &[f32], &[f32], &[f32], usize) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_planar_into(&self, &[f32], &[f32], &[f32], usize, &mut alloc::vec::Vec<f32>) -> core::result::Result<(f64, f64), ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_linear_with_stop(&self, &[f32], &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_srgb(&self, imgref::ImgRef<'_, rgb::RGB8>) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_srgb_with_stop(&self, imgref::ImgRef<'_, rgb::RGB8>, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_with_stop(&self, &[u8], &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::drop_strip_source(&mut self)
 pub fn precompute::ButteraugliReference::from_linear(imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, ButteraugliParams) -> core::result::Result<Self, ButteraugliError>
 pub fn precompute::ButteraugliReference::from_srgb(imgref::ImgRef<'_, rgb::RGB8>, ButteraugliParams) -> core::result::Result<Self, ButteraugliError>
@@ -53,11 +58,16 @@ pub fn precompute::ButteraugliReference::shrink_to_fit(&mut self)
 pub fn precompute::ButteraugliReference::width(&self) -> usize
 pub fn precompute::ButteraugliReference::compare_linear_strip(&self, &[f32], u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_strip_with_config(&self, &[f32], u32, ButteraugliStripConfig) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_linear_strip_with_stop(&self, &[f32], u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip(&self, &[u8], u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip_linear_imgref(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_strip_linear_imgref_with_stop(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip_srgb(&self, imgref::ImgRef<'_, rgb::RGB8>, u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_strip_srgb_with_stop(&self, imgref::ImgRef<'_, rgb::RGB8>, u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip_with_config(&self, &[u8], u32, ButteraugliStripConfig) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_strip_with_stop(&self, &[u8], u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 #[non_exhaustive] pub enum ButteraugliError
+pub ButteraugliError::Cancelled(enough::reason::StopReason)
 #[non_exhaustive] pub ButteraugliError::DimensionMismatch
 pub ButteraugliError::DimensionMismatch::h1: usize
 pub ButteraugliError::DimensionMismatch::h2: usize
@@ -91,9 +101,13 @@ pub struct ButteraugliReference [also: precompute]
 pub fn precompute::ButteraugliReference::compare(&self, &[u8]) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear(&self, &[f32]) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_imgref(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_linear_imgref_with_stop(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_planar(&self, &[f32], &[f32], &[f32], usize) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_planar_into(&self, &[f32], &[f32], &[f32], usize, &mut alloc::vec::Vec<f32>) -> core::result::Result<(f64, f64), ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_linear_with_stop(&self, &[f32], &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_srgb(&self, imgref::ImgRef<'_, rgb::RGB8>) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_srgb_with_stop(&self, imgref::ImgRef<'_, rgb::RGB8>, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_with_stop(&self, &[u8], &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::drop_strip_source(&mut self)
 pub fn precompute::ButteraugliReference::from_linear(imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, ButteraugliParams) -> core::result::Result<Self, ButteraugliError>
 pub fn precompute::ButteraugliReference::from_srgb(imgref::ImgRef<'_, rgb::RGB8>, ButteraugliParams) -> core::result::Result<Self, ButteraugliError>
@@ -106,10 +120,14 @@ pub fn precompute::ButteraugliReference::shrink_to_fit(&mut self)
 pub fn precompute::ButteraugliReference::width(&self) -> usize
 pub fn precompute::ButteraugliReference::compare_linear_strip(&self, &[f32], u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_linear_strip_with_config(&self, &[f32], u32, ButteraugliStripConfig) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_linear_strip_with_stop(&self, &[f32], u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip(&self, &[u8], u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip_linear_imgref(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_strip_linear_imgref_with_stop(&self, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip_srgb(&self, imgref::ImgRef<'_, rgb::RGB8>, u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_strip_srgb_with_stop(&self, imgref::ImgRef<'_, rgb::RGB8>, u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn precompute::ButteraugliReference::compare_strip_with_config(&self, &[u8], u32, ButteraugliStripConfig) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn precompute::ButteraugliReference::compare_strip_with_stop(&self, &[u8], u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 #[non_exhaustive] pub struct ButteraugliResult
 pub ButteraugliResult::diffmap: core::option::Option<imgref::ImgVec<f32>>
 pub ButteraugliResult::pnorm_3: f64
@@ -127,8 +145,11 @@ pub fn butteraugli(imgref::ImgRef<'_, rgb::RGB8>, imgref::ImgRef<'_, rgb::RGB8>,
 pub fn butteraugli_linear(imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, &ButteraugliParams) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn butteraugli_linear_strip(imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, &ButteraugliParams, u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn butteraugli_linear_strip_with_config(imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, &ButteraugliParams, u32, ButteraugliStripConfig) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn butteraugli_linear_with_stop(imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, imgref::ImgRef<'_, rgb::formats::rgb::Rgb<f32>>, &ButteraugliParams, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn butteraugli_strip(imgref::ImgRef<'_, rgb::RGB8>, imgref::ImgRef<'_, rgb::RGB8>, &ButteraugliParams, u32) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn butteraugli_strip_with_config(imgref::ImgRef<'_, rgb::RGB8>, imgref::ImgRef<'_, rgb::RGB8>, &ButteraugliParams, u32, ButteraugliStripConfig) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn butteraugli_strip_with_stop(imgref::ImgRef<'_, rgb::RGB8>, imgref::ImgRef<'_, rgb::RGB8>, &ButteraugliParams, u32, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
+pub fn butteraugli_with_stop(imgref::ImgRef<'_, rgb::RGB8>, imgref::ImgRef<'_, rgb::RGB8>, &ButteraugliParams, &dyn enough::Stop) -> core::result::Result<ButteraugliResult, ButteraugliError>
 pub fn srgb_to_linear(u8) -> f32
 
 ## trait impls (5 types)


### PR DESCRIPTION
## What

README usability fixes surfaced by an **insulated external-developer test** (a dev given *only* the README, no source). The biggest finding: the cooperative-cancellation API exists in the code but the README never mentioned it.

This PR carries the cancellation feature commit (`51edd31`, closes #8 — already on `feat-cooperative-cancellation`) **together with** its README documentation, so the shipped docs match the shipped code. The README edit itself is the second commit (`8039598`, README-only, +149 lines).

## The gaps fixed

1. **Cancellation API was undocumented (top fix).** `butteraugli_with_stop` / `butteraugli_linear_with_stop` / `butteraugli_strip_with_stop` and the warm-reference `compare*_with_stop` family take a trailing `stop: &dyn enough::Stop`. The README now has a **Cancellation** section: the plain↔`_with_stop` mapping table, the "checked at the outer per-scale / per-strip boundary, never in the hot loop" contract, `Err(ButteraugliError::Cancelled(enough::StopReason))` on cancel, `enough::Unstoppable` as the zero-cost no-op (re-exported as `butteraugli::enough`, no extra dep), and an `almost-enough::Stopper` (`new()` / `clone()` to a worker / `cancel()` from another thread) runtime example.
2. **Flat `Vec<u8>` → `Img<RGB8>` on-ramp.** The old example jumped straight to `let original: Vec<RGB8> = load_image()`, hiding the hardest step. Added a snippet building `Vec<RGB8>` from flat interleaved bytes via `RGB8::new(r,g,b)` + `chunks_exact(3)`, plus the strided `ImgRef::new_stride` note, and stated that `Img`/`RGB8`/`RGB`/`ImgRef` are re-exported so no extra dep is needed.
3. **RGBA has no path.** Added a callout: drop alpha by stepping `chunks_exact(4)` and keeping 3 — packing RGBA as RGB via `chunks_exact(3)` silently misaligns every pixel and produces a garbage score.
4. **Named the types** the test dev had to guess: error type `ButteraugliError` (`#[non_exhaustive]`, `impl std::error::Error`), `pnorm(&self, p: f64) -> Option<f64>`, `max_norm() -> f64`, and the diffmap type `ImgVec<f32>` — in a small "Types and Errors" table.

Every symbol was verified against `butteraugli/src/` on the branch. The existing distance-scale/threshold, `intensity_target`, and which-norm-is-the-score docs are unchanged. CHANGELOG already documents the cancellation API under `[Unreleased]/Added`, so it's untouched.