### PR TITLE
feat: add butteraugli_linear_strip_with_stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ overhead. When the token fires, the call returns
 | `butteraugli` | `butteraugli_with_stop` |
 | `butteraugli_linear` | `butteraugli_linear_with_stop` |
 | `butteraugli_strip` | `butteraugli_strip_with_stop` |
+| `butteraugli_linear_strip` | `butteraugli_linear_strip_with_stop` |
 | `ButteraugliReference::compare` | `compare_with_stop` |
 | `ButteraugliReference::compare_linear` | `compare_linear_with_stop` |
 | `ButteraugliReference::compare_srgb` | `compare_srgb_with_stop` |

--- a/butteraugli/src/lib.rs
+++ b/butteraugli/src/lib.rs
@@ -162,8 +162,8 @@ pub use precompute::ButteraugliReference;
 mod strip;
 pub use strip::{
     ButteraugliStripConfig, HALO_ROWS_DEFAULT, MIN_STRIP_HEIGHT, butteraugli_linear_strip,
-    butteraugli_linear_strip_with_config, butteraugli_strip, butteraugli_strip_with_config,
-    butteraugli_strip_with_stop,
+    butteraugli_linear_strip_with_config, butteraugli_linear_strip_with_stop, butteraugli_strip,
+    butteraugli_strip_with_config, butteraugli_strip_with_stop,
 };
 
 #[cfg(feature = "internals")]

--- a/butteraugli/src/strip.rs
+++ b/butteraugli/src/strip.rs
@@ -347,6 +347,38 @@ pub fn butteraugli_linear_strip(
     )
 }
 
+/// Like [`butteraugli_linear_strip`], but cooperatively cancellable via an
+/// [`enough::Stop`] token.
+///
+/// `stop` is checked once per strip, at the top of the strip loop (the
+/// outermost per-strip boundary); the per-strip diffmap kernels are never
+/// interrupted mid-strip. If the token signals a stop, returns
+/// [`ButteraugliError::Cancelled`] carrying the [`enough::StopReason`].
+///
+/// Pass [`enough::Unstoppable`] for a non-cancellable call (this is exactly
+/// what [`butteraugli_linear_strip`] does — it is zero-cost). Uses the default
+/// strip config (halo = [`HALO_ROWS_DEFAULT`]).
+///
+/// # Errors
+/// As [`butteraugli_linear_strip`], plus [`ButteraugliError::Cancelled`] if
+/// `stop` signals cancellation.
+pub fn butteraugli_linear_strip_with_stop(
+    img1: ImgRef<RGB<f32>>,
+    img2: ImgRef<RGB<f32>>,
+    params: &ButteraugliParams,
+    strip_height: u32,
+    stop: &dyn Stop,
+) -> Result<ButteraugliResult, ButteraugliError> {
+    butteraugli_linear_strip_with_config_and_stop(
+        img1,
+        img2,
+        params,
+        strip_height,
+        ButteraugliStripConfig::default(),
+        stop,
+    )
+}
+
 /// Strip-wise butteraugli with linear-RGB f32 inputs and explicit
 /// configuration.
 ///
@@ -358,6 +390,26 @@ pub fn butteraugli_linear_strip_with_config(
     params: &ButteraugliParams,
     strip_height: u32,
     config: ButteraugliStripConfig,
+) -> Result<ButteraugliResult, ButteraugliError> {
+    butteraugli_linear_strip_with_config_and_stop(
+        img1,
+        img2,
+        params,
+        strip_height,
+        config,
+        &enough::Unstoppable,
+    )
+}
+
+/// Shared body for the linear-RGB strip entry points; `stop` is threaded to the
+/// strip walker which checks it once per strip.
+fn butteraugli_linear_strip_with_config_and_stop(
+    img1: ImgRef<RGB<f32>>,
+    img2: ImgRef<RGB<f32>>,
+    params: &ButteraugliParams,
+    strip_height: u32,
+    config: ButteraugliStripConfig,
+    stop: &dyn Stop,
 ) -> Result<ButteraugliResult, ButteraugliError> {
     params.validate()?;
     let (width, height) = (img1.width(), img1.height());
@@ -389,7 +441,6 @@ pub fn butteraugli_linear_strip_with_config(
     check_finite_f32(&linear1, "linear rgb1")?;
     check_finite_f32(&linear2, "linear rgb2")?;
 
-    // No cancellation token on this entry point — `Unstoppable` is zero-cost.
     run_strip_walker_linear(
         &linear1,
         &linear2,
@@ -399,7 +450,7 @@ pub fn butteraugli_linear_strip_with_config(
         params,
         config.halo_rows,
         params.compute_diffmap(),
-        &enough::Unstoppable,
+        stop,
     )
 }
 

--- a/butteraugli/tests/cancellation.rs
+++ b/butteraugli/tests/cancellation.rs
@@ -7,7 +7,8 @@
 
 use butteraugli::{
     ButteraugliError, ButteraugliParams, ButteraugliReference, Img, RGB, RGB8,
-    butteraugli_linear_with_stop, butteraugli_strip_with_stop, butteraugli_with_stop,
+    butteraugli_linear_strip_with_stop, butteraugli_linear_with_stop, butteraugli_strip_with_stop,
+    butteraugli_with_stop,
 };
 
 /// Small deterministic sRGB test image (≥8×8 so the strip API accepts it).
@@ -182,6 +183,63 @@ fn butteraugli_strip_with_stop_unstoppable_matches_plain_strip() {
     let stopped =
         butteraugli_strip_with_stop(a.as_ref(), b.as_ref(), &params, 16, &enough::Unstoppable)
             .unwrap();
+
+    assert_eq!(plain.score, stopped.score);
+}
+
+#[test]
+fn butteraugli_linear_strip_with_stop_cancelled() {
+    let a = linear_image(32, 32, 0);
+    let b = linear_image(32, 32, 5);
+    let params = ButteraugliParams::default();
+
+    let result = butteraugli_linear_strip_with_stop(
+        a.as_ref(),
+        b.as_ref(),
+        &params,
+        16,
+        &almost_enough::Stopper::cancelled(),
+    );
+
+    assert!(
+        matches!(result, Err(ButteraugliError::Cancelled(_))),
+        "expected Cancelled, got {result:?}"
+    );
+}
+
+#[test]
+fn butteraugli_linear_strip_with_stop_unstoppable_ok() {
+    let a = linear_image(32, 32, 0);
+    let b = linear_image(32, 32, 5);
+    let params = ButteraugliParams::default();
+
+    let result = butteraugli_linear_strip_with_stop(
+        a.as_ref(),
+        b.as_ref(),
+        &params,
+        16,
+        &enough::Unstoppable,
+    )
+    .expect("Unstoppable must not cancel");
+
+    assert!(result.score.is_finite());
+}
+
+#[test]
+fn butteraugli_linear_strip_with_stop_unstoppable_matches_plain_strip() {
+    let a = linear_image(32, 32, 0);
+    let b = linear_image(32, 32, 5);
+    let params = ButteraugliParams::default();
+
+    let plain = butteraugli::butteraugli_linear_strip(a.as_ref(), b.as_ref(), &params, 16).unwrap();
+    let stopped = butteraugli_linear_strip_with_stop(
+        a.as_ref(),
+        b.as_ref(),
+        &params,
+        16,
+        &enough::Unstoppable,
+    )
+    .unwrap();
 
     assert_eq!(plain.score, stopped.score);
 }


### PR DESCRIPTION
`butteraugli_linear_strip` was the only public slow entry point without a `*_with_stop twin`, so linear RGB callers could only get coarse check-once-at-entry cancellation (via `butteraugli_linear_with_stop`), never per-strip mid-flight cancellation. a090b0d left this one path with a hardcoded `&enough::Unstoppable`.

Mirror the sRGB strip structure exactly
- `private butteraugli_linear_strip_with_config_and_stop` shared body that threads `stop` into `run_strip_walker_linear`
- `butteraugli_linear_strip_with_config` delegates with `&enough::Unstoppable`
- new public `butteraugli_linear_strip_with_stop` delegates with default config
- `butteraugli_linear_strip` unchanged

Re-exported from `lib.rs` and added to the README cancellable twins table.

Tests mirror the sRGB strip trio.

Closes #13 